### PR TITLE
Fix cmake variable reference to prevent full system recursion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,8 @@ include_directories(${dbot_ros_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 set(dbot_ros_SOURCE_DIR source/${PROJECT_NAME})
 
 file(GLOB_RECURSE dbot_ros_HEADERS
-    ${dbot_SOURCE_DIR}/*.hpp
-    ${dbot_SOURCE_DIR}/*.h)
+    ${dbot_ros_SOURCE_DIR}/*.hpp
+    ${dbot_ros_SOURCE_DIR}/*.h)
 
 set(dbot_ros_SOURCES
     source/${PROJECT_NAME}/object_tracker_ros.cpp


### PR DESCRIPTION
The variable `dbot_SOURCE_DIR` referenced in CMakeLists.txt is not set in this file. As such, it takes it as an empty string, and you end up recursing on the ENTIRE filesystem. Kind of awesome, it was looking for headers in my trash and in other user accounts.

The fix is simply use `dbot_ros_SOURCE_DIR` instead. An added benefit is it takes significantly less time to compile now.