### PR TITLE
Export cv_bridge as dependency and refactor package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ catkin_package(
     sensor_msgs
     std_msgs
     geometry_msgs
+    cv_bridge
     message_filters
     image_transport
     fl

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>dbot_ros</name>
   <version>0.1.0</version>
   <description>The dbot_ros package</description>
@@ -15,32 +15,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>roslib</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>OpenCV</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>fl</build_depend>
-  <build_depend>dbot</build_depend>
-  <build_depend>dbot_ros_msgs</build_depend>
-  <build_depend>interactive_markers</build_depend>
-
-  <run_depend>roscpp</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>OpenCV</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>fl</run_depend>
-  <run_depend>dbot</run_depend>
-  <run_depend>dbot_ros_msgs</run_depend>
-  <run_depend>interactive_markers</run_depend>
+  <depend>roscpp</depend>
+  <depend>roslib</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>OpenCV</depend>
+  <depend>cv_bridge</depend>
+  <depend>message_filters</depend>
+  <depend>image_transport</depend>
+  <depend>fl</depend>
+  <depend>dbot</depend>
+  <depend>dbot_ros_msgs</depend>
+  <depend>interactive_markers</depend>
 
   <export>
     <!-- <metapackage/> -->


### PR DESCRIPTION
cv_bridge is needed for packages that use dbot_ros, so it needs to be
listed in the `CATKIN_DEPENDS` section.  For this, it also needs to be
added as run dependency.

Refactor package.xml to use format 2.